### PR TITLE
Feat/minor improvement

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -383,7 +383,7 @@ async function stopVotingForSession(session) {
   });
 
   if (!session.isPause) {
-    const timestamp = new Date().getTime() + 1000 + 100;
+    const timestamp = new Date().getTime() + session.preloadDuration;
     sendToAllClients(session, timestamp, {
       m: MESSAGES.MSG_SHOW,
       showIdx: mostVoteRingId,
@@ -454,7 +454,7 @@ async function jumpScoreForSession(session, value) {
   });
 
   if (!session.isPause) {
-    sendToAllClients(session, Date.now() + 100, {
+    sendToAllClients(session, Date.now() + session.preloadDuration, {
       m: MESSAGES.MSG_SHOW,
       showIdx: index,
     });
@@ -556,7 +556,7 @@ async function messageHandle(conn, message) {
         history: session.history,
         selectedIdx: session.historyIndex,
       });
-      sendToAllClientsWithDelay(session, 100, {
+      sendToAllClientsWithDelay(session, session.preloadDuration, {
         m: MESSAGES.MSG_SHOW,
         showIdx: session.currentIndex,
       });

--- a/database.js
+++ b/database.js
@@ -202,6 +202,7 @@ class BMSession {
   holdDuration = 0;
   votingDuration = 10;
   votingSize = 100;
+  preloadDuration = 1100;
   hasSounds = false;
 
   get qrSharePath() {

--- a/public/javascripts/audio-player.js
+++ b/public/javascripts/audio-player.js
@@ -215,9 +215,20 @@ class Note {
       soundInst.on("end", () => {
         this.playingCount--;
       });
+      let retryCount = 0;
       soundInst.on("loaderror", (...e) => {
         logMismatchSound();
         console.error(`Unable to load sound ${sn}`, ...e);
+        if (retryCount < 1) {
+          retryCount++;
+          const retryDelay = 1000 + Math.random() * 4000;
+          setTimeout(() => {
+            soundInst.unload();
+            soundInst.load();
+          }, retryDelay);
+        } else {
+          window.sessionInstance?.markSoundLoadFailed(sn);
+        }
       });
 
       return soundInst;
@@ -394,6 +405,7 @@ class AudioSession {
   guideLock = false;
 
   soundLoadSet = new Set();
+  failedSounds = new Set();
 
   autoPlay = false;
 
@@ -472,9 +484,11 @@ class AudioSession {
       if (this.autoPlay) {
         initialFrame.playAllAutoplayNotes();
       }
-      initialFrame
-        .getAllSoundNameInFrame()
-        .forEach((s) => this.markSoundAsLoading(s));
+      initialFrame.getAllSoundNameInFrame().forEach((s) => {
+        if (!this.failedSounds.has(s)) {
+          this.markSoundAsLoading(s);
+        }
+      });
       Howler.stop();
       return;
     }
@@ -506,7 +520,12 @@ class AudioSession {
         });
         prevNote.stop();
       } else {
-        note.soundNames.forEach((sn) => this.markSoundAsLoading(sn));
+        note.soundNames.forEach((sn, idx) => {
+          if (this.failedSounds.has(sn)) return;
+          if (note.soundInstances[idx].state() !== "loaded") {
+            this.markSoundAsLoading(sn);
+          }
+        });
         note.loadNoteSounds();
 
         if (this.autoPlay && note.isAutoplay) {
@@ -553,10 +572,35 @@ class AudioSession {
     togglerElement.dataset.active = this.autoPlay;
   }
 
+  preloadFrameAudio(frameIdx) {
+    console.log("preload");
+    const frame = this.frameMap[`svg${frameIdx}`];
+    if (!frame) return;
+    for (const note of frame.notes) {
+      note.loadNoteSounds();
+    }
+  }
+
   markSoundAsLoading(soundKey) {
     this.soundLoadSet.add(soundKey);
 
     document.body.classList.toggle("loading-sound", true);
+  }
+
+  markSoundLoadFailed(soundKey) {
+    this.failedSounds.add(soundKey);
+    this.soundLoadSet.delete(soundKey);
+
+    document.body.classList.toggle(
+      "loading-sound",
+      this.soundLoadSet.size !== 0,
+    );
+    document.body.classList.add("loading-sound-error");
+
+    const indicator = document.getElementById("loading-sound-indicator");
+    if (indicator) {
+      indicator.textContent = "please refresh your browser";
+    }
   }
 
   handleSoundLoaded(loadedSound) {

--- a/public/javascripts/audio-player.js
+++ b/public/javascripts/audio-player.js
@@ -506,6 +506,17 @@ class AudioSession {
       }
     }
 
+    // Sweep all frames other than prev (already handled above) and next
+    // (about to start) to stop any sounds that leaked from earlier frames.
+    for (const [frameId, frame] of Object.entries(this.frameMap)) {
+      if (frameId === prevId || frameId === nextId) continue;
+      for (const note of frame.notes) {
+        if (note.playingCount > 0) {
+          note.fadeStop(fadeDuration);
+        }
+      }
+    }
+
     console.log(
       "Common sound notes between prev and current frame:",
       Object.keys(continueNotes),
@@ -699,11 +710,11 @@ document.addEventListener(
   false,
 );
 
-window.onbeforeunload = () => {
+window.addEventListener("pagehide", () => {
   Howler.unload();
   window.sessionInstance = null;
   window.removeEventListener("update-view", handleOnUpdateView);
-};
+});
 
 console.log("Session instance", window.sessionInstance);
 

--- a/public/javascripts/ws-client.js
+++ b/public/javascripts/ws-client.js
@@ -51,6 +51,9 @@ function onWsOpen() {
 function onWsMessage(event) {
   const data = JSON.parse(event.data);
   const delay = Math.max(0, data.t - getServerTime());
+  if (data.m === MSG_SHOW && delay > 0 && data.showIdx !== -1) {
+    window.sessionInstance?.preloadFrameAudio(data.showIdx);
+  }
   delay === 0 ? parseMessage(data) : setTimeout(parseMessage, delay, data);
 }
 

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -530,6 +530,16 @@ body.ipad {
   display: block;
 }
 
+.loading-sound-error #loading-sound-indicator {
+  display: block;
+  color: #c0392b;
+}
+
+.loading-sound-error #loading-sound-indicator::before {
+  animation: none;
+  width: 0;
+}
+
 #loading-sound-indicator {
   font-size: 18px;
   color: #9a9a9a;

--- a/routes/sm.js
+++ b/routes/sm.js
@@ -37,6 +37,7 @@ router.get("/", async function (req, res) {
     const adminpassword = query.sp;
     const playerpassword = query.pp;
     const fadeDuration = Number(query.fadeDuration);
+    const preloadDuration = Number(query.preloadDuration);
     const isHtml5 = Boolean(query.isHtml5);
     const defaultVolume = Number(query.defaultVolume);
     const defaultAutoplay = Boolean(query.defaultAutoplay);
@@ -74,6 +75,7 @@ router.get("/", async function (req, res) {
           {
             isHtml5,
             fadeDuration,
+            preloadDuration: preloadDuration >= 0 ? preloadDuration : session.preloadDuration,
             holdDuration: hold >= 0 ? hold : session.holdDuration,
             votingDuration: vote >= 0 ? vote : session.votingDuration,
             votingSize: size >= 0 ? size : session.votingSize,
@@ -149,6 +151,7 @@ router.get("/", async function (req, res) {
           const size = parseInt(votingSize);
           await session.patchState(
             {
+              preloadDuration: preloadDuration >= 0 ? preloadDuration : session.preloadDuration,
               holdDuration: hold >= 0 ? hold : session.holdDuration,
               votingDuration: vote >= 0 ? vote : session.votingDuration,
               votingSize: size >= 0 ? size : session.votingSize,

--- a/views/sm.jade
+++ b/views/sm.jade
@@ -60,6 +60,11 @@ block content
               input(type="number" name="fadeDuration", value=d.fadeDuration, min=0)
           tr
             td
+              label(for="preloadDuration") &nbsp;buffer duration(ms)&nbsp;
+            td
+              input(type="number" name="preloadDuration", value=d.preloadDuration, min=0)
+          tr
+            td
               label(for="votingSize") &nbsp;voting size (%)&nbsp;
             td
               input(type="number" name="votingSize",  value=d.votingSize, min=1)
@@ -157,6 +162,11 @@ block content
           label(for="fadeDuration") &nbsp;fade duration(ms)&nbsp;
         td
           input(type="number" name="fadeDuration", value=1000, min=0)
+      tr
+        td
+          label(for="preloadDuration") &nbsp;buffer duration(ms)&nbsp;
+        td
+          input(type="number" name="preloadDuration", value=1100, min=0)
       tr
         td
           label(for="votingSize") &nbsp;voting size (%)&nbsp;


### PR DESCRIPTION
## Summary

- **Preload audio during buffer window**: When a `MSG_SHOW` message arrives with a future timestamp, the client now uses the delay window to preload audio for the incoming frame before it's displayed, reducing audio latency at frame transitions.
- **Configurable preload/buffer duration**: Added a `preloadDuration` session property (default `1100ms`) that controls how far ahead transitions are scheduled. Exposed as a `buffer duration (ms)` field in the session manager UI and accepted as a `preloadDuration` query param.
- **Reliable sound load failure handling**: Added retry logic (1 attempt, 1–5s random delay) on `loaderror`. If the retry also fails, the sound is marked as permanently failed, the loading indicator shows "please refresh your browser" in red, and the failed sound is excluded from future load-set tracking so it doesn't block the UI indefinitely.
- **Force-stop leaked sounds from earlier frames**: On each frame transition, any frame other than the previous and next is swept and faded out if it still has playing notes, preventing audio from earlier frames from leaking through.
- **Fix `onbeforeunload` → `pagehide`**: Replaced `window.onbeforeunload` with `window.addEventListener("pagehide", ...)` for more reliable cleanup (Howler unload + session teardown) on modern browsers, including mobile Safari.

